### PR TITLE
Pillow Support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,6 @@
 [DESIGN]
+# Maximum object variables.
 max-attributes=10
+# Maximum local variables.
+# Default: 15
+max-locals=16

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ This is aimed for use with independent and free card games that are intended for
 
 ## Installation
 
-Install ImageMagick and Python 3 on a Linux system.
-
 Stable CGC releases can be downloaded from [here](https://github.com/ekultails/card_games_converter/releases).
 
 ```
@@ -18,10 +16,10 @@ $ pip install --user cgc
 
 ## Usage
 
-* Create the directory `/tmp/cards/`.
+* Create the directory `/tmp/cards/` (Linux and macOS) or `C:\TEMP\cards\` (Windows).
 * Copy individual images of cards to be printed to that directory.
 * Execute the CGC program: `cgc-cli.py`
-* Print the resulting pages from `/tmp/cgc/horizontal/`.
+* Print the resulting pages from `/tmp/cgc/horizontal/` (Linux and macOS) or `C:\TEMP\cgc\horizontal\` (Windows).
 
 ### CLI
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The [Star Wars Trading Card Game (TCG)](http://starwars.wikia.com/wiki/Star_Wars
 Download the "Zipped Card JPGs" archive of an expansion pack of playing cards from [here](https://swtcgidc.wordpress.com/expansions-home/). Extract the archive and copy the desired cards to print into a different folder. Then use CGC to process the cards.
 
 ```
-./cgc-cli.py --src /home/user/Documents/cards_to_print/
+$ cgc-cli.py --src /home/user/Documents/cards_to_print/
 ```
 
 Printable pages of cards with the correct size and pixel density will be created and placed in the directory `/tmp/cgc/horizontal/`.
@@ -67,7 +67,7 @@ The cache modes decreases the amount of time to re-process similar images. It wa
 * sha512 = A checksum check to see if an image has been modified already.
 
 ```
-$ ./cgc-cli.py --cache name
+$ cgc-cli.py --cache name
 ```
 
 # Developers

--- a/cgc/cgc.py
+++ b/cgc/cgc.py
@@ -77,13 +77,13 @@ class CGC:
             image_path (str)
 
         Returns:
-            list: height, width
+            list: width, height
         """
 
         with Image.open(image_path) as image:
-            height, width = image.size
+            width, height = image.size
 
-        return height, width
+        return width, height
 
     def calc_ppi(self, image_dimensions):
         """Calculate the pixels per inch density based on the desired
@@ -91,13 +91,13 @@ class CGC:
         an image.
 
         Args:
-            image_dimensions (list): height, width
+            image_dimensions (list): width, height
 
         Returns:
             ppi (int)
         """
-        height_ppi = image_dimensions[0] / self.height_physical_inches
-        width_ppi = image_dimensions[1] / self.width_physical_inches
+        width_ppi = image_dimensions[0] / self.width_physical_inches
+        height_ppi = image_dimensions[1] / self.height_physical_inches
         logging.debug("Height PPI = %d, Width PPI = %d", height_ppi,
                       width_ppi)
         # Find the average PPI and round up.
@@ -151,9 +151,9 @@ class CGC:
         Returns:
             boolean: If the image was successfully rotated.
         """
-        height, width = self.image_info(image_path)
+        width, height = self.image_info(image_path)
 
-        if width > height:
+        if width < height:
             logging.debug("Rotating image: %s", image_path)
 
             if not self.image_rotate(image_path, image_path):

--- a/cgc/cgc.py
+++ b/cgc/cgc.py
@@ -4,7 +4,6 @@
 """
 
 import logging
-import subprocess
 from os import listdir, makedirs
 from os.path import basename, exists, isdir
 from math import ceil
@@ -103,29 +102,6 @@ class CGC:
         # Find the average PPI and round up.
         ppi = ceil((height_ppi + width_ppi) / 2)
         return ppi
-
-    @staticmethod
-    def run_cmd(cmd):
-        """Execute a command.
-
-        Args:
-            cmd (list): a list of a command and arguments
-
-        Returns:
-            cmd_return (dict):
-                rc (int): return code
-                stdout (str bytes)
-                stderr (str bytes)
-        """
-        cmd_return = {"rc": None, "stdout": None, "stderr": None}
-        logging.debug("Running command: %s", " ".join(cmd))
-        convert_process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE)
-        cmd_return["stdout"], cmd_return["stderr"] = \
-            convert_process.communicate()
-        cmd_return["rc"] = int(convert_process.wait())
-        logging.debug("convert command output: %s", str(cmd_return))
-        return cmd_return
 
     @staticmethod
     def image_rotate(image_path_src, image_path_dest, degrees=90):

--- a/cgc/cgc.py
+++ b/cgc/cgc.py
@@ -127,7 +127,8 @@ class CGC:
         logging.debug("convert command output: %s", str(cmd_return))
         return cmd_return
 
-    def image_rotate(self, image_path_src, image_path_dest, degrees=90):
+    @staticmethod
+    def image_rotate(image_path_src, image_path_dest, degrees=90):
         """Execute the convert command to rotate an image.
 
         Args:
@@ -138,8 +139,9 @@ class CGC:
             boolean: If the convert command completed successfully.
         """
         image = Image.open(image_path_src)
-        image_rotated = image.rotate(angle=90, expand=True)
+        image_rotated = image.rotate(angle=degrees, expand=True)
         image_rotated.save(image_path_dest)
+        image.close()
         return True
 
     def image_rotate_by_dimensions(self, image_path):
@@ -161,7 +163,8 @@ class CGC:
 
         return True
 
-    def image_density_change(self, image_path_src, image_path_dest, ppi):
+    @staticmethod
+    def image_density_change(image_path_src, image_path_dest, ppi):
         """Change the density of the pixels per inch of an image.
 
         Args:
@@ -334,7 +337,7 @@ class CGC:
                            card_file_name)
 
         if not self.image_density_change(image_path_src,
-                                          image_path_dest, ppi):
+                                         image_path_dest, ppi):
             return False
 
         if not self.image_rotate_by_dimensions(image_path_dest):

--- a/cgc/cgc.py
+++ b/cgc/cgc.py
@@ -317,11 +317,9 @@ class CGC:
         if images_merge_method == "vertical":
             merged_height = image_heights
             # Find and use the width of the first image.
-            #merged_width = image_paths_open[0].width
             merged_width = max(image_widths_all)
         elif images_merge_method == "horizontal":
             # Find and use the height of the first image.
-            #merged_height = image_paths_open[0].height
             merged_height = max(image_heights_all)
             merged_width = image_widths
         else:

--- a/cgc/cgc.py
+++ b/cgc/cgc.py
@@ -4,6 +4,7 @@
 """
 
 import logging
+import tempfile
 from os import listdir, makedirs
 from os.path import basename, exists, isdir
 from math import ceil
@@ -16,7 +17,8 @@ import pkg_resources
 class CGC:
     """CGC provides methods for reformatting cards into printable sheets."""
 
-    def __init__(self, tmp_dest_dir="/tmp/cgc", height_physical_inches=2.5,
+    def __init__(self, tmp_dest_dir="{}/cgc".format(tempfile.gettempdir()),
+                 height_physical_inches=2.5,
                  width_physical_inches=3.5, log_level="INFO"):
         """Initialize CGC by creating temporary directories
         and setting the standard phsical size of a card.
@@ -29,7 +31,7 @@ class CGC:
         self.cache_mode = None
         self.height_physical_inches = height_physical_inches
         self.width_physical_inches = width_physical_inches
-        self.tmp_src_dir = "/tmp/cards"
+        self.tmp_src_dir = "{}/cards".format(tempfile.gettempdir())
         self.tmp_dest_dir = tmp_dest_dir
         self.tmp_dir_individual = self.tmp_dest_dir + "/individual"
         self.tmp_dir_horizontal = self.tmp_dest_dir + "/horizontal"

--- a/cgc/cgc.py
+++ b/cgc/cgc.py
@@ -127,7 +127,7 @@ class CGC:
         logging.debug("convert command output: %s", str(cmd_return))
         return cmd_return
 
-    def image_rotate(self, image_path_src, image_path_dest, degrees="90"):
+    def image_rotate(self, image_path_src, image_path_dest, degrees=90):
         """Execute the convert command to rotate an image.
 
         Args:
@@ -138,23 +138,11 @@ class CGC:
             boolean: If the convert command completed successfully.
         """
         image = Image.open(image_path_src)
-        image_rotated = None
-
-        if degrees == "90":
-            image_rotated = image.transpose(Image.ROTATE_90)
-        elif degrees == "180":
-            image_rotated = image.transpose(Image.ROTATE_180)
-        elif degrees == "270":
-            image_rotated = image.transpose(Image.ROTATE_270)
-        else:
-            logging.error("Incorrect degrees specified. Please use " + \
-                          "90, 180, or 270.")
-            return False
-
+        image_rotated = image.rotate(angle=90, expand=True)
         image_rotated.save(image_path_dest)
         return True
 
-    def convert_rotate_by_dimensions(self, image_path):
+    def image_rotate_by_dimensions(self, image_path):
         """Rotate an image only if the width is greater than the height.
 
         Args:
@@ -349,7 +337,7 @@ class CGC:
                                           image_path_dest, ppi):
             return False
 
-        if not self.convert_rotate_by_dimensions(image_path_dest):
+        if not self.image_rotate_by_dimensions(image_path_dest):
             return False
 
         return True
@@ -357,7 +345,7 @@ class CGC:
     def convert_batch_directory(self, images_dir):
         """Convert an entire directory from a specified path to be
         a different density and rotate them if needed. (Both the
-        "image_density_change" and "convert_rotate_by_dimensions" methods
+        "image_density_change" and "image_rotate_by_dimensions" methods
         are used on each image.
 
         Args:

--- a/cgc/cgc.py
+++ b/cgc/cgc.py
@@ -127,7 +127,7 @@ class CGC:
         logging.debug("convert command output: %s", str(cmd_return))
         return cmd_return
 
-    def convert_rotate(self, image_path_src, image_path_dest, degrees="90"):
+    def image_rotate(self, image_path_src, image_path_dest, degrees="90"):
         """Execute the convert command to rotate an image.
 
         Args:
@@ -137,12 +137,21 @@ class CGC:
         Returns:
             boolean: If the convert command completed successfully.
         """
-        cmd = ["convert", "-rotate", degrees, image_path_src,
-               image_path_dest]
+        image = Image.open(image_path_src)
+        image_rotated = None
 
-        if self.run_cmd(cmd)["rc"] != 0:
+        if degrees == "90":
+            image_rotated = image.transpose(Image.ROTATE_90)
+        elif degrees == "180":
+            image_rotated = image.transpose(Image.ROTATE_180)
+        elif degrees == "270":
+            image_rotated = image.transpose(Image.ROTATE_270)
+        else:
+            logging.error("Incorrect degrees specified. Please use " + \
+                          "90, 180, or 270.")
             return False
 
+        image_rotated.save(image_path_dest)
         return True
 
     def convert_rotate_by_dimensions(self, image_path):
@@ -159,7 +168,7 @@ class CGC:
         if width > height:
             logging.debug("Rotating image: %s", image_path)
 
-            if not self.convert_rotate(image_path, image_path):
+            if not self.image_rotate(image_path, image_path):
                 return False
 
         return True

--- a/cgc/cgc.py
+++ b/cgc/cgc.py
@@ -284,7 +284,7 @@ class CGC:
         return files_cache_invalid
 
     def images_merge(self, images_merge_method, image_paths,
-                      merged_image_name="out.jpg"):
+                     merged_image_name="out.jpg"):
         """Merge one or more images either vertically or horizontally.
         This requires that a new PIL image be created with the correct
         dimensions and then have all of the images pasted in it with a
@@ -445,7 +445,7 @@ class CGC:
             if image_count >= image_count_max:
 
                 if not self.images_merge(append_method, image_paths,
-                                          str(total_count) + ".jpg"):
+                                         str(total_count) + ".jpg"):
                     return False
 
                 # Reset the count and paths if 2 (horizontal) or 4 (veritcal)
@@ -459,7 +459,7 @@ class CGC:
                 if total_count == number_of_images:
 
                     if not self.images_merge(append_method, image_paths,
-                                              str(total_count) + ".jpg"):
+                                             str(total_count) + ".jpg"):
                         return False
 
         return True

--- a/cgc/cgc.py
+++ b/cgc/cgc.py
@@ -173,7 +173,7 @@ class CGC:
 
         return True
 
-    def convert_image_density(self, image_path_src, image_path_dest, ppi):
+    def image_density_change(self, image_path_src, image_path_dest, ppi):
         """Change the density of the pixels per inch of an image.
 
         Args:
@@ -184,12 +184,8 @@ class CGC:
         Returns:
             boolean: If the convert density command finished successfully
         """
-        cmd = ["convert", "-units", "PixelsPerInch", "-density", str(ppi),
-               image_path_src, image_path_dest]
-
-        if self.run_cmd(cmd)["rc"] != 0:
-            return False
-
+        image = Image.open(image_path_src)
+        image.save(image_path_dest, dpi=(ppi, ppi))
         return True
 
     @staticmethod
@@ -349,7 +345,7 @@ class CGC:
         image_path_dest = (self.tmp_dir_individual + "/" +
                            card_file_name)
 
-        if not self.convert_image_density(image_path_src,
+        if not self.image_density_change(image_path_src,
                                           image_path_dest, ppi):
             return False
 
@@ -361,7 +357,7 @@ class CGC:
     def convert_batch_directory(self, images_dir):
         """Convert an entire directory from a specified path to be
         a different density and rotate them if needed. (Both the
-        "convert_image_density" and "convert_rotate_by_dimensions" methods
+        "image_density_change" and "convert_rotate_by_dimensions" methods
         are used on each image.
 
         Args:

--- a/cgc_tdd.md
+++ b/cgc_tdd.md
@@ -123,7 +123,7 @@ The "Card Games Converter" (CGC) is a utility for converting pictures of cards i
 | 1.2.0 | 8 | 2 |
 | 1.3.0 | 4 | 5 |
 | 1.3.1 | 4 | 1 |
-| 1.4.0 | 4 | |
+| 1.4.0 | 4 | 3 |
 | 1.5.0 | 4 | |
 | 2.0.0 | 40 | |
 
@@ -200,3 +200,5 @@ Commands: `$ echo 3 | sudo tee /proc/sys/vm/drop_caches && sync && time ./cgc-cl
         * Prioritize PyPI support and changed milestone from target version `1.6.0` to `1.3.1`.
         * Prioritize the milestone for only using native Python libraries for image processing.
     * Completed milestone `1.3.1`.
+* 2018-11-19
+    * Completed milestone `1.4.0`.

--- a/cgc_tdd.md
+++ b/cgc_tdd.md
@@ -47,7 +47,7 @@ The "Card Games Converter" (CGC) is a utility for converting pictures of cards i
         * image_path (src) = The full path to the image.
     * Ouput
         * boolean = If this method was successful.
-* convert_image_density = Convert a single image to a specific physical size density based on the PPI.
+* image_density_change = Convert a single image to a specific physical size density based on the PPI.
     * Inputs
         * image_path_src (str) = The full path to the source image to convert.
         * image_path_dest (str) = The full path to the destination image to save as.

--- a/cgc_tdd.md
+++ b/cgc_tdd.md
@@ -7,8 +7,7 @@ The "Card Games Converter" (CGC) is a utility for converting pictures of cards i
 # Technologies
 
 * Python 3.6
-    * PIL
-* imagemagick
+    * PIL (Pillow)
 * Linux
 
 # Functions
@@ -29,14 +28,6 @@ The "Card Games Converter" (CGC) is a utility for converting pictures of cards i
         * image_dimensions (list) = The resolution height and width of an image.
     * Ouput
         * ppi (int) = The pixels per inch density.
-* run_cmd = Execute a shell command.
-    * Input
-        * cmd (list) = A list of a command and arguments for it.
-    * Ouputs
-        * cmd_return (dict)
-            * rc (int) = Return code.
-            * stdout (str bytes) = Standard output.
-            * stderr (str bytes) = Standard error.
 * image_rotate = Rotate an image.
     * Input
         * image_path (str) = The full image path to use.

--- a/cgc_tdd.md
+++ b/cgc_tdd.md
@@ -22,8 +22,8 @@ The "Card Games Converter" (CGC) is a utility for converting pictures of cards i
     * Input
         * image_path (str) = The full path to an image.
     * Outputs
-        * height (int)
         * width (int)
+        * height (int)
 * calc_ppi = Calculate and return the PPI for an image based on it's height and width.
     * Input
         * image_dimensions (list) = The resolution height and width of an image.

--- a/cgc_tdd.md
+++ b/cgc_tdd.md
@@ -37,7 +37,7 @@ The "Card Games Converter" (CGC) is a utility for converting pictures of cards i
             * rc (int) = Return code.
             * stdout (str bytes) = Standard output.
             * stderr (str bytes) = Standard error.
-* convert_rotate = Rotate an image.
+* image_rotate = Rotate an image.
     * Input
         * image_path (str) = The full image path to use.
     * Ouput

--- a/cgc_tdd.md
+++ b/cgc_tdd.md
@@ -42,7 +42,7 @@ The "Card Games Converter" (CGC) is a utility for converting pictures of cards i
         * image_path (str) = The full image path to use.
     * Ouput
         * boolean = If this method was successful.
-* convert_rotate_by_dimensions = Rotate an image if the width is greater than the height. This allows for stacking of images for a printable page of 8 cards.
+* image_rotate_by_dimensions = Rotate an image if the width is greater than the height. This allows for stacking of images for a printable page of 8 cards.
     * Input
         * image_path (src) = The full path to the image.
     * Ouput

--- a/cgc_tdd.md
+++ b/cgc_tdd.md
@@ -6,9 +6,9 @@ The "Card Games Converter" (CGC) is a utility for converting pictures of cards i
 
 # Technologies
 
-* Python 3.6
+* Python >= 3.6
     * PIL (Pillow)
-* Linux
+* Linux, macOS, or Windows
 
 # Functions
 

--- a/cgc_tdd.md
+++ b/cgc_tdd.md
@@ -54,7 +54,7 @@ The "Card Games Converter" (CGC) is a utility for converting pictures of cards i
         * ppi (int) = The desired pixels per inch density.
     * Ouput
         * boolean = If this method was successful.
-* convert_merge = Merge one or more images together either vertically or horizontally.
+* images_merge = Merge one or more images together either vertically or horizontally.
     * Inputs
         * convert_merge_method (str) = Append the images together in the "vertical" or "horizontal" direction
         * images_paths (list) = A list of all of the full image paths to append together.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 
 setuptools.setup(
     name="cgc",
-    version="1.3.1",
+    version="1.4.0",
     author="Luke Short",
     author_email="ekultails@gmail.com",
     url="https://github.com/ekultails/card_games_converter",

--- a/tests.py
+++ b/tests.py
@@ -79,12 +79,12 @@ class CGCUnitTests(unittest.TestCase):
            (not return_status):
             self.assertTrue(False)
 
-    def test_convert_rotate_by_dimensions(self):
+    def test_image_rotate_by_dimensions(self):
         rotate_image = self.cgc.tmp_dest_dir + "/rotate.jpg"
         copyfile(self.last_image_card, rotate_image)
         # Return a list of: height, width
         rotate_image_original = self.cgc.image_info(rotate_image)
-        return_status = self.cgc.convert_rotate_by_dimensions(rotate_image)
+        return_status = self.cgc.image_rotate_by_dimensions(rotate_image)
         rotate_image_new = self.cgc.image_info(rotate_image)
 
         if not return_status:

--- a/tests.py
+++ b/tests.py
@@ -97,9 +97,9 @@ class CGCUnitTests(unittest.TestCase):
         if rotate_image_original[1] < rotate_image_original[0]:
             self.assertTrue(rotate_image_new[1] < rotate_image_new[0])
 
-    def test_convert_image_density(self):
+    def test_image_density_change(self):
         # Set a temporary card to have the pixels per inch density of 104.
-        self.cgc.convert_image_density(self.last_image_card,
+        self.cgc.image_density_change(self.last_image_card,
                                        self.tmp_card, 104)
         cmd = ["identify", "-format", '%x', self.tmp_card]
         density_x_results = self.cgc.run_cmd(cmd)

--- a/tests.py
+++ b/tests.py
@@ -106,7 +106,7 @@ class CGCUnitTests(unittest.TestCase):
         card_1 = self.cgc.tmp_src_dir + "/1.jpg"
         card_2 = self.cgc.tmp_src_dir + "/2.jpg"
         image_paths = [card_1, card_2]
-        cards_merged_full_path = "/tmp/cgc/vertical/merged.jpg"
+        cards_merged_full_path = "{}/cgc/vertical/merged.jpg".format(tempfile.gettempdir())
         cards_merged = basename(cards_merged_full_path)
 
         if (not self.cgc.images_merge("vertical", image_paths, cards_merged)) \

--- a/tests.py
+++ b/tests.py
@@ -68,9 +68,9 @@ class CGCUnitTests(unittest.TestCase):
             and (convert_results["rc"] != 0):
             self.assertTrue(False)
 
-    def test_convert_rotate(self):
+    def test_image_rotate(self):
         image_dimensions_old = self.cgc.image_info(self.last_image_card)
-        return_status = self.cgc.convert_rotate(self.last_image_card,
+        return_status = self.cgc.image_rotate(self.last_image_card,
                                                 self.tmp_card)
         image_dimensions_new = self.cgc.image_info(self.tmp_card)
 

--- a/tests.py
+++ b/tests.py
@@ -115,14 +115,14 @@ class CGCUnitTests(unittest.TestCase):
                          density_y_results["stdout"].decode()):
             self.assertTrue(False)
 
-    def test_convert_merge(self):
+    def test_images_merge(self):
         card_1 = self.cgc.tmp_src_dir + "/1.jpg"
         card_2 = self.cgc.tmp_src_dir + "/2.jpg"
         image_paths = [card_1, card_2]
         cards_merged_full_path = "/tmp/cgc/vertical/merged.jpg"
         cards_merged = basename(cards_merged_full_path)
 
-        if (not self.cgc.convert_merge("vertical", image_paths, cards_merged)) \
+        if (not self.cgc.images_merge("vertical", image_paths, cards_merged)) \
             or (not isfile(cards_merged_full_path)):
             self.assertTrue(False)
 
@@ -173,7 +173,6 @@ class CGCUnitTests(unittest.TestCase):
             self.assertTrue(False)
         elif return_status == False:
             self.assertTrue(False)
-
 
     def tearDown(self):
         rmtree(self.cards_source_dir)

--- a/tests.py
+++ b/tests.py
@@ -57,7 +57,7 @@ class CGCUnitTests(unittest.TestCase):
                 self.assertTrue(False)
 
     def test_calc_ppi(self):
-        image_dimensions = [260, 364]
+        image_dimensions = [364, 260]
         self.assertEqual(self.cgc.calc_ppi(image_dimensions), 104)
 
     def test_run_cmd(self):
@@ -82,7 +82,7 @@ class CGCUnitTests(unittest.TestCase):
     def test_image_rotate_by_dimensions(self):
         rotate_image = self.cgc.tmp_dest_dir + "/rotate.jpg"
         copyfile(self.last_image_card, rotate_image)
-        # Return a list of: height, width
+        # Return a list of: width, height
         rotate_image_original = self.cgc.image_info(rotate_image)
         return_status = self.cgc.image_rotate_by_dimensions(rotate_image)
         rotate_image_new = self.cgc.image_info(rotate_image)
@@ -91,10 +91,10 @@ class CGCUnitTests(unittest.TestCase):
             self.assertTrue(False)
 
         # Images only get rotated if the width is larger than the height.
-        if rotate_image_original[1] > rotate_image_original[0]:
+        if rotate_image_original[1] < rotate_image_original[0]:
             self.assertTrue(rotate_image_new[1] < rotate_image_new[0])
 
-        if rotate_image_original[1] < rotate_image_original[0]:
+        if rotate_image_original[1] > rotate_image_original[0]:
             self.assertTrue(rotate_image_new[1] < rotate_image_new[0])
 
     def test_image_density_change(self):

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import tempfile
 import unittest
 from os import listdir, makedirs, remove
 from os.path import basename, exists, isfile
@@ -13,7 +14,7 @@ from cgc.cgc import CGC
 class CGCUnitTests(unittest.TestCase):
 
     def setUp(self):
-        self.tmp_root_dir = "/tmp"
+        self.tmp_root_dir = tempfile.gettempdir()
         self.cards_source_dir = self.tmp_root_dir + "/cards"
         self.last_image_card = self.tmp_root_dir + "/cards/9.jpg"
         self.example_card_url = "https://swtcgidc.files.wordpress.com/2018/08/card-of-the-week-bosb029_starkiller_base_b.jpg"


### PR DESCRIPTION
Avoid using shell commands to remove the external dependency on ImageMagick and to provide cross-platform support.